### PR TITLE
NSDV-110 directory search results a to z

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ typings/
 
 # dotenv environment variables file
 .env
+.env.local
 
 # OSX
 .DS_Store

--- a/ui/components/Dataset/index.js
+++ b/ui/components/Dataset/index.js
@@ -70,20 +70,21 @@ function SortMenu({ searchTerm }) {
       value: 'score desc',
     },
     {
+      label: 'Name (A to Z)',
+      value: 'name asc',
+      selected: 'selected',
+    },
+    {
+      label: 'Name (Z to A)',
+      value: 'name desc',
+    },
+    {
       label: 'Added (newest)',
       value: 'metadata_created desc',
     },
     {
       label: 'Added (oldest)',
       value: 'metadata_created asc',
-    },
-    {
-      label: 'Name (A to Z)',
-      value: 'name asc',
-    },
-    {
-      label: 'Name (Z to A)',
-      value: 'name desc',
     },
   ];
 
@@ -165,7 +166,7 @@ export default function Dataset({
   includeType,
   schema,
 }) {
-  const { query } = useQueryContext();
+  const { query, updateQuery } = useQueryContext();
   const searchTerm = query.q;
   const [data, setData] = useState(initialData);
   const [loading, setLoading] = useState(false);
@@ -185,15 +186,22 @@ export default function Dataset({
         setLoading(false);
       }
     }
+
     // we dont want to fetch data on initial load.
     if (pageLoaded) {
       getData();
     }
+
     // we don't want pageLoaded in the dependency array
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query]);
 
-  useEffect(() => setPageLoaded(true), []);
+  useEffect(() => {
+    const orderBy = 'name';
+    const order = 'asc';
+    updateQuery({ orderBy, order });
+    setPageLoaded(true);
+  }, []);
 
   return (
     <>

--- a/ui/components/Dataset/index.js
+++ b/ui/components/Dataset/index.js
@@ -199,7 +199,7 @@ export default function Dataset({
   useEffect(() => {
     const orderBy = 'name';
     const order = 'asc';
-    updateQuery({ orderBy, order });
+    updateQuery({ ...query, orderBy, order });
     setPageLoaded(true);
   }, []);
 


### PR DESCRIPTION
1.  Implements default ordering of directory search results to A-Z asc.
2.  Adds env.local to .gitignore at all levels of repo for additional security.
