### PR TITLE
NSDV-111 -  main action link should follow NHS design standard

### DIFF
--- a/ui/components/ActionLink/index.js
+++ b/ui/components/ActionLink/index.js
@@ -1,0 +1,41 @@
+import styles from './style.module.scss';
+
+const ActionLink = ({ link = false, title = '' }) => {
+  return !link ? (
+    'Not available'
+  ) : (
+    <>
+      <div className="nhsuk-action-link">
+        <a
+          className="nhsuk-action-link__link"
+          href={link}
+          rel="noreferrer"
+          target="_blank"
+          title={`Documentation for ${title}`}
+        >
+          <svg
+            className="nhsuk-icon nhsuk-icon__arrow-right-circle"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+            width="36"
+            height="36"
+          >
+            <path d="M0 0h24v24H0z" fill="none"></path>
+            <path d="M12 2a10 10 0 0 0-9.95 9h11.64L9.74 7.05a1 1 0 0 1 1.41-1.41l5.66 5.65a1 1 0 0 1 0 1.42l-5.66 5.65a1 1 0 0 1-1.41 0 1 1 0 0 1 0-1.41L13.69 13H2.05A10 10 0 1 0 12 2z"></path>
+          </svg>
+          <span className={`nhsuk-action-link__text ${styles.linkText}`}>
+            View documentation for this standard
+          </span>
+        </a>
+      </div>
+      <div>
+        <span className="nhsuk-u-visually-hidden">opens in a new tab</span>
+        <br />
+        (opens in new tab)
+      </div>
+    </>
+  );
+};
+
+export default ActionLink;

--- a/ui/components/ActionLink/style.module.scss
+++ b/ui/components/ActionLink/style.module.scss
@@ -1,0 +1,3 @@
+.linkText {
+  font-size: 1.2em;
+}

--- a/ui/schema/index.js
+++ b/ui/schema/index.js
@@ -10,6 +10,7 @@ import {
   Dt,
 } from '../components';
 import format from 'date-fns/format';
+import ActionLink from '../components/ActionLink';
 
 // `!!val?.length` => check whether empty array or unset val
 
@@ -155,7 +156,8 @@ const schema = [
         <>
           {val && <MarkdownBlock md={val} />}
           {data.documentation_link && (
-            <DocumentationLink
+            <ActionLink
+              id="documentation-link"
               link={data.documentation_link}
               title={data.title}
             />


### PR DESCRIPTION
1.  Breaks out the document link into an ActionLink component for easy reuse if required.
2. Implements NHS Design Standard for Action Link.
3. Includes minor styling modifications (in modular css file) to make link text visually compatible with goals of  NHS Design Standard.