### PR TITLE
NSDV-107 - Implements future and published standards showing in searc…

### DIFF
--- a/ui/helpers/api.js
+++ b/ui/helpers/api.js
@@ -134,8 +134,6 @@ export async function list(
 
   const query = getSearchQuery(q);
   const ckanQuery = stringify({ q: query, fq, rows, start, sort: sortstring });
-  console.log('Filters', filters);
-  console.log('ckanQuery', ckanQuery);
   return callApi(`${CKAN_URL}/package_search?${ckanQuery}`);
 }
 

--- a/ui/helpers/api.js
+++ b/ui/helpers/api.js
@@ -98,15 +98,10 @@ export async function getPages() {
   return callApi(`${PAGES_CKAN_URL}/ckanext_pages_list`);
 }
 
-export async function list({
-  page = 1,
-  q,
-  sort,
-  inactive,
-  orderBy,
-  order,
-  ...filters
-}) {
+export async function list(
+  { page = 1, q, sort, inactive, orderBy, order, ...filters },
+  futureAndPublished = false
+) {
   if (!sort) {
     if (orderBy) {
       sort = {
@@ -131,12 +126,16 @@ export async function list({
       .join(', ');
   }
 
-  filters.is_published_standard = !inactive;
+  if (!futureAndPublished) {
+    filters.is_published_standard = !inactive;
+  }
 
   fq = serialise(queriseSelections(filters));
 
   const query = getSearchQuery(q);
   const ckanQuery = stringify({ q: query, fq, rows, start, sort: sortstring });
+  console.log('Filters', filters);
+  console.log('ckanQuery', ckanQuery);
   return callApi(`${CKAN_URL}/package_search?${ckanQuery}`);
 }
 

--- a/ui/helpers/getPageProps.js
+++ b/ui/helpers/getPageProps.js
@@ -1,10 +1,14 @@
 import { list, schema, getPages } from './api';
 import { getHost } from './getHost';
-export async function getPageProps({ req, query }, options = {}) {
+export async function getPageProps(
+  { req, query },
+  options = {},
+  futureAndPublished = false
+) {
   return {
     props: {
       host: await getHost(req),
-      data: await list(query),
+      data: await list(query, futureAndPublished),
       schemaData: await schema(),
       pages: await getPages(),
       searchTerm: query.q || '',

--- a/ui/pages/search-results.js
+++ b/ui/pages/search-results.js
@@ -65,5 +65,5 @@ SearchResults.Layout = function SearchResults({ children }) {
 };
 
 export async function getServerSideProps(context) {
-  return await getPageProps(context, { content });
+  return await getPageProps(context, { content }, true);
 }


### PR DESCRIPTION
Modified API helpers and call to API helpers from /search-results page to pull in all standards, published and future published.

Changes do not affect results in /published-standards page which still only shows published standards

