### PR TITLE
NSDV-109 - FIX - turn off automatic mandated filtering

### DIFF
--- a/ui/components/Filters/index.js
+++ b/ui/components/Filters/index.js
@@ -13,12 +13,12 @@ const CheckBox = () => {
 
   const selections = getSelections();
 
-  useEffect(() => {
-    const name = 'mandated';
-    delete selections[name];
-    selections[name] = true;
-    updateQuery(selections, { replace: true });
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  // useEffect(() => {
+  //   const name = 'mandated';
+  //   delete selections[name];
+  //   selections[name] = true;
+  //   updateQuery(selections, { replace: true });
+  // }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const toggleMandated = (event) => {
     const { name, checked } = event.target;

--- a/ui/components/Filters/index.js
+++ b/ui/components/Filters/index.js
@@ -13,13 +13,6 @@ const CheckBox = () => {
 
   const selections = getSelections();
 
-  // useEffect(() => {
-  //   const name = 'mandated';
-  //   delete selections[name];
-  //   selections[name] = true;
-  //   updateQuery(selections, { replace: true });
-  // }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
   const toggleMandated = (event) => {
     const { name, checked } = event.target;
     delete selections[name];


### PR DESCRIPTION
FIXES issue with "mandated" being automatically filtered out when visiting 'future-standards" page.  Issue was introduced when implementing original NSDV-109 feature