### PR TITLE
NSDV-108 - FIXES default A-Z ordering of results after published/futu…

### DIFF
--- a/ui/pages/published-standards/index.js
+++ b/ui/pages/published-standards/index.js
@@ -23,8 +23,11 @@ export default function Standards({ data, schemaData, host }) {
   const { getSelections, updateQuery } = useQueryContext();
 
   useEffect(() => {
+    const currentSelections = getSelections();
+    const order = currentSelections.order || 'asc'
+    const orderBy = currentSelections.orderBy || 'name'
     const mandated = 'true';
-    const selections = { ...getSelections(), mandated };
+    const selections = { ...currentSelections, mandated, order, orderBy };
     updateQuery(selections, { replace: true });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);


### PR DESCRIPTION
…re filter added.

Previous work on adding the published standard/future standard filter broke the default A-Z ordering of standards in the /published-standards page.

This has now been fixed for this page to default to A-Z unless 'order' and 'orderBy' values exist in the query string.

NOTE:  At this point in time, once the PR to develop has been approved, the fixes will be merged to Test and UAT without further PR Approval.  The code will then be pushed to the associated test and uat MDW servers ready for review by NHSE.