### PR TITLE
EX-12008 hide 'legal authority description' if empty value

### DIFF
--- a/ui/schema/index.js
+++ b/ui/schema/index.js
@@ -304,6 +304,7 @@ const schema = [
       format: (val) => !!val?.length && <MarkdownBlock md={val} />,
     },
     legal_authority_description: {
+      hide_when_empty: true,
       label: 'Legal authority description',
       format: (val) => !!val?.length && <MarkdownBlock md={val} />,
     },


### PR DESCRIPTION
added hide_when_empty property to field legal_authority_description in schema