### PR TITLE
EX-12159 escape spatial charters

### DIFF
--- a/ui/components/Dataset/index.js
+++ b/ui/components/Dataset/index.js
@@ -12,10 +12,15 @@ import DOMPurify from 'isomorphic-dompurify';
 export const formatDate = (date, dateFormat = 'd MMM yyyy') =>
   format(parseISO(date), dateFormat);
 
+function escapeRegExp(text) {
+  return text && text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+}
+
 function Embolden({ children }) {
   const { getSelections } = useQueryContext();
   const { q } = getSelections();
-  const re = new RegExp(`(${q})`, 'ig');
+  const escapedQuery = escapeRegExp(q);
+  const re = new RegExp(`(${escapedQuery})`, 'ig');
   const replaced = children ? children.replace(re, '<strong>$1</strong>') : '';
 
   return (


### PR DESCRIPTION
as well escaped spatial charters in browser api #https://github.com/MetadataWorks/browser-api/pull/923