### PR TITLE
EX-12169 update label from Implementation from date to effective from

### DIFF
--- a/ui/schema/index.js
+++ b/ui/schema/index.js
@@ -226,7 +226,7 @@ const schema = [
       format: (val) => formatDate(val),
     },
     implementation_from_date: {
-      label: 'Implementation from date',
+      label: 'Effective from',
       format: (val) => formatDate(val),
     },
   },


### PR DESCRIPTION
also made sure that all stack has the same data
![Screenshot from 2023-07-20 14-34-07](https://github.com/MetadataWorks/standards-registry/assets/73431463/56104d6d-04e5-4fb0-9cd2-07eca24bb00b)
![Screenshot from 2023-07-20 14-34-33](https://github.com/MetadataWorks/standards-registry/assets/73431463/63d202d3-031b-4348-87dc-26d49340868c)
![Screenshot from 2023-07-20 14-34-58](https://github.com/MetadataWorks/standards-registry/assets/73431463/ea4caf8a-d588-482e-a76c-2e2d7beeaeb8)

Effective from was mapped to Implementation from date, so that was displayed with the corresponding label. The same happened with Conformance Date, which was mapped to Comply by. Please let me know if this should be labeled as Conformance Date instead of Comply by.

